### PR TITLE
Define contrast sensivity in terms of brightness.

### DIFF
--- a/requirements.html
+++ b/requirements.html
@@ -188,7 +188,9 @@ ul, ol {
         </section>
     <section>
           <h3>Contrast Sensitivity</h3>
-          <p>Contrast sensitivity is the ability to distinguish bright and dim areas of images, for example, to discern colored text on a colored background. A person with low contrast sensitivity cannot see text when there is not sufficient <em>luminosity</em> contrast between the text and the background, for example, light gray text on a light background. Most people lose contrast sensitivity as they age.</p>
+	    <p>Contrast sensitivity is the ability to distinguish bright and dim areas of images. For example, a person may be able to read white text on black background, but her sight may not be sensitive enough to the read dark grey text on black background.  A person's contrast sensitivity is a measure of the difference in brightness required so that foreground shapes and can be distinguished from the background. A person who could read dark grey text on black background would have a  high contrast sensitivity. Most people lose contrast sensitivity as they age, and almost everyone with low vision has low contrast sensitivity.</p>
+	<p>Contrast sensitivity does not depend on the color palette. For example, a  pie chart that uses color to distinguish fields will be very difficult to perceive for people low contrast sensitivity if all of the fields have the same level of brightness. </p>
+
           <p class="listintro">User needs related to contrast sensitivity are addressed in the following section:</p>
           <ul>
         <li><a href="http://w3c.github.io/low-vision-a11y-tf/requirements.html#luminance-and-color">3.1 Luminance and Color</a></li>


### PR DESCRIPTION
Extend the scope to include most of low vision. Remove the luminosity and luminance meaning confusion. Exclude color as a factor.
