### PR TITLE
Informal description of luminance.

### DIFF
--- a/requirements.html
+++ b/requirements.html
@@ -286,7 +286,7 @@ telecon, see <a href="https://www.w3.org/2002/09/wbs/81151/UserNeeds-Jan-27/resu
       <p>Each section briefly explains  the issue and the user experience, and then states a specific user need after "User Need - ".  User Needs that say &ldquo;Users can...&rdquo;  indicates that users can change a setting.</p>
       <section>
     <h2>Luminance and Color</h2>
-    <p>Luminance is basically brightness. It is explained more in the <a href="#light-sensitivity">Light Sensitivity</a> section above.</p>
+    <p>Luminance is a metric to measure brightness. High luminance is bright and low luminance is dim. </p>
     <section>
           <h3>Luminance Overall</h3>
           <p>Bright light from a screen or other sources prevents some people with low vision (including those with photophobia and with reading disabilities such as dyslexia) from reading and causes pain for some people. Some people turn down the brightness of their screen or use an overlay.</p>


### PR DESCRIPTION
The removal of luminance and luminosity from light and contrast sensitivity renders the background link wrong. This describes luminance without getting into the meaning formally.
