### PR TITLE
color vision tweaks to match others

### DIFF
--- a/requirements.html
+++ b/requirements.html
@@ -189,7 +189,7 @@
         </section>
     <section>
           <h3>Color Vision</h3>
-          <p>Some people cannot see certain colors well or at all, usually because of deficiencies in the cone receptors of their eyes which are responsible for color perception. This is commonly called “color blindness”, even though most people who are color blind can see most colors. It is rare that a person cannot see any color at all. Globally, approximately 1 in 12 men (8%) and 1 in 200 women have  color vision deficiencies. [<em>Draft Note:</em> Reference to be added; some listed in <a href="https://www.w3.org/WAI/GL/low-vision-a11y-tf/wiki/References#Color_Vision">References</a>.] Color vision deficiencies are  not classified as “low vision” or disabilities in many contexts.<!--  Additional information is linked from <a href="https://www.w3.org/WAI/users/low-vision/">Accessibility for People with Low Vision</a>. --></p>
+          <p>Some people do not see certain colors well or at all. Color vision deficiencies are commonly called “color blindness”, even though most people who are color blind can see many colors. It is rare that a person cannot see any color at all. Globally, approximately 1 in 12 men (8%) and 1 in 200 women have  color vision deficiencies. [<em>Draft Note:</em> Reference to be added; some listed in <a href="https://www.w3.org/WAI/GL/low-vision-a11y-tf/wiki/References#Color_Vision">References</a>.] Color vision deficiencies are  not classified as “low vision” or disabilities in many contexts.<!--  Additional information is linked from <a href="https://www.w3.org/WAI/users/low-vision/">Accessibility for People with Low Vision</a>. --></p>
           <p>Simulated examples of color blindness:</p>
           <figure><img alt="Color wheel with 12 different colors" width="190" height="190" src="images/full_color.png" />
         <figcaption>Full color perception</figcaption>
@@ -235,7 +235,7 @@
     </section>
         </section>
 <section>
-      <h2>User Needs</h2>
+  <h2>User Needs</h2>
       <!-- @@ edit &/or lvtf review: [Low vision accessibility is largely about perceiving textual information. ...] -->
       <p>User needs varying widely across people who have low vision, and one user’s needs may conflict with another user’s needs. For example, an older person might need high contrast but that might be unreadable to a person with light sensitivity; a person with good visual acuity (clarity) and tunnel vision might need to make the text size small so they can see more words at a time to read better, whereas most people with low visual acuity need large text.</p>
     <p class="issue">The Task Force plans to expand this section.</p>


### PR DESCRIPTION
Suggest deleting the cause and tweaking to introduce "color vision deficiencies" clearly.
Rationale: 2.4.2 Light Sensitivity, 2.4.3 Contrast Sensitivity, and 2.4.4 Field of Vision do not include the cause. And we're probably deleting it from 2.4.1 Visual Acuity (Clarity) per issue https://github.com/w3c/low-vision-a11y-tf/issues/35
